### PR TITLE
add higher-order differentiation, collocation matrix, knot vector utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,21 @@ This fork adds higher-order differentiation, collocation matrix generation, and 
     #
     y3 = numpy.sum( A0 * c, axis=-1 )
 
+
+# Installation
+
+Copy the `.py` files next to your source code,
+or leave them in this directory and call it as a module.
+
+Tested on Python 2.7 and 3.4.
+
+Tested on Linux Mint.
+
+# Dependencies
+
+* [NumPy](http://www.numpy.org)
+* [Matplotlib](http://matplotlib.org/) (for demo script)
+
+# License
+
+[MIT](LICENSE.md)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
-#Bspline.py
+# Bspline.py
 
-Python/Numpy implementation of Bspline basis functions via Cox - de Boor algorithm
+Python/Numpy implementation of Bspline basis functions via Cox - de Boor algorithm.
+
+This fork adds higher-order differentiation, collocation matrix generation, and a minimal procedural API (mainly for dealing with knot vectors) which may help in converting MATLAB codes.
+

--- a/README.md
+++ b/README.md
@@ -6,66 +6,67 @@ This fork adds higher-order differentiation, collocation matrix generation, and 
 
 # Usage
 
-    import numpy
-    import bspline
-    import splinelab
+```python
+import numpy
+import bspline
+import splinelab
 
-    ## Spline setup and evaluation
+## Spline setup and evaluation
 
-    p = 3              # order of spline (as-is; 3 = cubic)
-    nknots = 11        # number of knots to generate (here endpoints count only once)
-    tau = [0.1, 0.33]  # collocation sites (i.e. where to evaluate)
+p = 3              # order of spline (as-is; 3 = cubic)
+nknots = 11        # number of knots to generate (here endpoints count only once)
+tau = [0.1, 0.33]  # collocation sites (i.e. where to evaluate)
 
-    knots = numpy.linspace(0,1,nknots)  # create a knot vector without endpoint repeats
-    k     = splinelab.augknt(knots, p)  # add endpoint repeats as appropriate for spline order p
-    B     = bspline.Bspline(k, p)       # create spline basis of order p on knots k
+knots = numpy.linspace(0,1,nknots)  # create a knot vector without endpoint repeats
+k     = splinelab.augknt(knots, p)  # add endpoint repeats as appropriate for spline order p
+B     = bspline.Bspline(k, p)       # create spline basis of order p on knots k
 
-    A0 = B.collmat(tau)                 # collocation matrix for function value at sites tau
-    A2 = B.collmat(tau, deriv_order=2)  # collocation matrix for second derivative at sites tau
+A0 = B.collmat(tau)                 # collocation matrix for function value at sites tau
+A2 = B.collmat(tau, deriv_order=2)  # collocation matrix for second derivative at sites tau
 
-    print( A0 )
-    print( A2 )
+print( A0 )
+print( A2 )
 
-    D3 = B.diff(order=3)  # third derivative of B as lambda x: ...
-    print( D3(0.4) )
+D3 = B.diff(order=3)  # third derivative of B as lambda x: ...
+print( D3(0.4) )
 
-    D  = numpy.array( [D3(t) for t in tau], dtype=numpy.float64 )  # third derivative of B at sites tau
-
-
-    ## Spline setup by defining collocation sites
-
-    ncolloc = 7
-    tau = numpy.linspace(0,1,ncolloc)  # These are the sites to which we would like to interpolate
-    k   = splinelab.aptknt(tau, p)     # Given the collocation sites, generate a knot vector
-                                       # (incl. endpoint repeats). To get meaningful results,
-                                       # here one must choose ncolloc such that  ncolloc >= p+1.
-    B   = bspline.Bspline(k, p)
-
-    A0  = B.collmat(tau)
-
-    print( A0 )
+D  = numpy.array( [D3(t) for t in tau], dtype=numpy.float64 )  # third derivative of B at sites tau
 
 
-    ## Evaluate a function expressed in the spline basis:
+## Spline setup by defining collocation sites
 
-    # set up coefficients (in a real use case, fill this with something sensible,
-    #                      e.g. with an L2 projection onto the spline basis)
-    #
-    nbasis = A0.shape[1]  # A0.shape = (num_collocation_sites, num_basis_functions)
-    c = numpy.ones( (nbasis,), dtype=numpy.float64 )
+ncolloc = 7
+tau = numpy.linspace(0,1,ncolloc)  # These are the sites to which we would like to interpolate
+k   = splinelab.aptknt(tau, p)     # Given the collocation sites, generate a knot vector
+                                   # (incl. endpoint repeats). To get meaningful results,
+                                   # here one must choose ncolloc such that  ncolloc >= p+1.
+B   = bspline.Bspline(k, p)
 
-    # evaluate f(0.4)
-    y1 = numpy.sum( B(0.4) * c )
+A0  = B.collmat(tau)
 
-    # evaluate at each tau[k]
-    y2 = numpy.array( [numpy.sum( B(t) * c ) for t in tau], dtype=numpy.float64 )
+print( A0 )
 
-    # equivalent, using the collocation matrix
-    #
-    # NOTE: the sites tau are built into the matrix when collmat() is called.
-    #
-    y3 = numpy.sum( A0 * c, axis=-1 )
 
+## Evaluate a function expressed in the spline basis:
+
+# set up coefficients (in a real use case, fill this with something sensible,
+#                      e.g. with an L2 projection onto the spline basis)
+#
+nbasis = A0.shape[1]  # A0.shape = (num_collocation_sites, num_basis_functions)
+c = numpy.ones( (nbasis,), dtype=numpy.float64 )
+
+# evaluate f(0.4)
+y1 = numpy.sum( B(0.4) * c )
+
+# evaluate at each tau[k]
+y2 = numpy.array( [numpy.sum( B(t) * c ) for t in tau], dtype=numpy.float64 )
+
+# equivalent, using the collocation matrix
+#
+# NOTE: the sites tau are built into the matrix when collmat() is called.
+#
+y3 = numpy.sum( A0 * c, axis=-1 )
+```
 
 # Installation
 

--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ This fork adds higher-order differentiation, collocation matrix generation, and 
 
     ncolloc = 7
     tau = numpy.linspace(0,1,ncolloc)  # These are the sites to which we would like to interpolate
-    k   = splinelab.aptknt(tau, p)     # Given the collocation sites, generate a knot vector (incl. endpoint repeats).
-                                       # To get meaningful results, here one must choose ncolloc such that  ncolloc >= p+1.
+    k   = splinelab.aptknt(tau, p)     # Given the collocation sites, generate a knot vector
+                                       # (incl. endpoint repeats). To get meaningful results,
+                                       # here one must choose ncolloc such that  ncolloc >= p+1.
     B   = bspline.Bspline(k, p)
 
     A0  = B.collmat(tau)
@@ -47,7 +48,8 @@ This fork adds higher-order differentiation, collocation matrix generation, and 
 
     ## Evaluate a function expressed in the spline basis:
 
-    # set up coefficients (in a real use case, fill this with something sensible, e.g. with an L2 projection onto the spline basis)
+    # set up coefficients (in a real use case, fill this with something sensible,
+    #                      e.g. with an L2 projection onto the spline basis)
     #
     nbasis = A0.shape[1]  # A0.shape = (num_collocation_sites, num_basis_functions)
     c = numpy.ones( (nbasis,), dtype=numpy.float64 )
@@ -58,6 +60,9 @@ This fork adds higher-order differentiation, collocation matrix generation, and 
     # evaluate at each tau[k]
     y2 = numpy.array( [numpy.sum( B(t) * c ) for t in tau], dtype=numpy.float64 )
 
-    # equivalent, using the collocation matrix (NOTE: the sites tau are built into the matrix when collmat() is called)
+    # equivalent, using the collocation matrix
+    #
+    # NOTE: the sites tau are built into the matrix when collmat() is called.
+    #
     y3 = numpy.sum( A0 * c, axis=-1 )
 

--- a/README.md
+++ b/README.md
@@ -4,3 +4,60 @@ Python/Numpy implementation of Bspline basis functions via Cox - de Boor algorit
 
 This fork adds higher-order differentiation, collocation matrix generation, and a minimal procedural API (mainly for dealing with knot vectors) which may help in converting MATLAB codes.
 
+# Usage
+
+    import numpy
+    import bspline
+    import splinelab
+
+    ## Spline setup and evaluation
+
+    p = 3              # order of spline (as-is; 3 = cubic)
+    nknots = 11        # number of knots to generate (here endpoints count only once)
+    tau = [0.1, 0.33]  # collocation sites (i.e. where to evaluate)
+
+    knots = numpy.linspace(0,1,nknots)  # create a knot vector without endpoint repeats
+    k     = splinelab.augknt(knots, p)  # add endpoint repeats as appropriate for spline order p
+    B     = bspline.Bspline(k, p)       # create spline basis of order p on knots k
+
+    A0 = B.collmat(tau)                 # collocation matrix for function value at sites tau
+    A2 = B.collmat(tau, deriv_order=2)  # collocation matrix for second derivative at sites tau
+
+    print( A0 )
+    print( A2 )
+
+    D3 = B.diff(order=3)  # third derivative of B as lambda x: ...
+    print( D3(0.4) )
+
+    D  = numpy.array( [D3(t) for t in tau], dtype=numpy.float64 )  # third derivative of B at sites tau
+
+
+    ## Spline setup by defining collocation sites
+
+    ncolloc = 7
+    tau = numpy.linspace(0,1,ncolloc)  # These are the sites to which we would like to interpolate
+    k   = splinelab.aptknt(tau, p)     # Given the collocation sites, generate a knot vector (incl. endpoint repeats).
+                                       # To get meaningful results, here one must choose ncolloc such that  ncolloc >= p+1.
+    B   = bspline.Bspline(k, p)
+
+    A0  = B.collmat(tau)
+
+    print( A0 )
+
+
+    ## Evaluate a function expressed in the spline basis:
+
+    # set up coefficients (in a real use case, fill this with something sensible, e.g. with an L2 projection onto the spline basis)
+    #
+    nbasis = A0.shape[1]  # A0.shape = (num_collocation_sites, num_basis_functions)
+    c = numpy.ones( (nbasis,), dtype=numpy.float64 )
+
+    # evaluate f(0.4)
+    y1 = numpy.sum( B(0.4) * c )
+
+    # evaluate at each tau[k]
+    y2 = numpy.array( [numpy.sum( B(t) * c ) for t in tau], dtype=numpy.float64 )
+
+    # equivalent, using the collocation matrix (NOTE: the sites tau are built into the matrix when collmat() is called)
+    y3 = numpy.sum( A0 * c, axis=-1 )
+

--- a/bspline.py
+++ b/bspline.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
+"""Python/Numpy implementation of Bspline basis functions via Cox - de Boor algorithm."""
 
 from __future__ import division
 
 from functools import partial
 import numpy as np
-import matplotlib.pyplot as plt
 
 class memoize(object):
     """
@@ -138,6 +138,8 @@ class Bspline():
            range of knots.
         """
 
+        import matplotlib.pyplot as plt
+
         x_min = np.min(self.knot_vector)
         x_max = np.max(self.knot_vector)
 
@@ -156,6 +158,8 @@ class Bspline():
            Convenience function to plot derivatives of basis functions over
            full range of knots.
         """
+
+        import matplotlib.pyplot as plt
 
         x_min = np.min(self.knot_vector)
         x_max = np.max(self.knot_vector)

--- a/bspline.py
+++ b/bspline.py
@@ -169,3 +169,125 @@ class Bspline():
             plt.plot(x,n)
 
         return plt.show()
+
+
+    def __diff_internal(self):
+        """Differentiate a B-spline once, and return the resulting coefficients and Bspline objects.
+
+This preserves the Bspline object nature of the data, enabling recursive implementation
+of higher-order differentiation (see `diff`).
+
+The value of the first derivative of `B` at a point `x` can be obtained as::
+
+    def diff1(B, x):
+        terms = B.__diff_internal()
+        return sum( ci*Bi(x) for ci,Bi in terms )
+
+Returns:
+    tuple of tuples, where each item is (coefficient, Bspline object).
+
+See:
+    `diff`: differentiation of any order >= 0
+"""
+        assert self.p > 0, "order of Bspline must be > 0"  # we already handle the other case in diff()
+
+        # https://www.cs.mtu.edu/~shene/COURSES/cs3621/NOTES/spline/B-spline/bspline-derv.html
+        #
+        t    = self.knot_vector
+        p    = self.p
+        Bi   = Bspline( t[:-1], p-1 )
+        Bip1 = Bspline( t[1:],  p-1 )
+
+        numer1 = +p
+        numer2 = -p
+        denom1 = t[p:-1]   - t[:-(p+1)]
+        denom2 = t[(p+1):] - t[1:-p]
+
+        with np.errstate(divide='ignore', invalid='ignore'):
+            ci   = np.where(denom1 != 0., (numer1 / denom1), 0.)
+            cip1 = np.where(denom2 != 0., (numer2 / denom2), 0.)
+
+        return ( (ci,Bi), (cip1,Bip1) )
+
+
+    def diff(self, order=1):
+        """Differentiate a B-spline `order` number of times.
+
+Parameters:
+    order:
+        int, >= 0
+
+Returns:
+    **lambda** `x`: ... that evaluates the `order`-th derivative of `B` at the point `x`.
+"""
+        order = int(order)
+        if order < 0:
+            raise ValueError("order must be >= 0, got %d" % (order))
+
+        if order == 0:
+            return self.__call__
+
+        if order > self.p:   # identically zero, but force the same output format as in the general case
+            dummy = self.__call__(0.)  # get number of basis functions and output dtype
+            nbasis = dummy.shape[0]
+            return lambda x: np.zeros( (nbasis,), dtype=dummy.dtype )  # accept but ignore input x
+
+        # At each differentiation, each term maps into two new terms.
+        # The number of terms in the result will be 2**order.
+        #
+        # This will cause an exponential explosion in the number of terms for high derivative orders,
+        # but for the first few orders (practical usage; >3 is rarely needed) the approach works.
+        #
+        terms = [ (1.,self) ]
+        for k in range(order):
+            tmp = []
+            for Ci,Bi in terms:
+                tmp.extend( (Ci*cn, Bn) for cn,Bn in Bi.__diff_internal() )  # NOTE: also propagate Ci
+            terms = tmp
+
+        # perform final summation at call time
+        return lambda x: sum( ci*Bi(x) for ci,Bi in terms )
+
+
+    def collmat(self, tau, deriv_order=0):
+        """Compute collocation matrix.
+
+Parameters:
+    tau:
+        Python list or rank-1 array, collocation sites
+    deriv_order:
+        int, >=0, order of derivative for which to compute the collocation matrix.
+        The default is 0, which means the function value itself.
+
+Returns:
+    A:
+        rank-2 array such that
+            A[i,j] = D**deriv_order B_j(tau[i])
+        where
+            D**k  = kth derivative (0 for function value itself)
+
+Example:
+    If the coefficients of a spline function are given in the vector c, then::
+
+        sum( A[i,:] * c[:] )
+
+    will give a rank-1 array of function values at the sites tau[i] that were supplied
+    to `collmat`.
+
+    Similarly for derivatives (if the supplied `deriv_order`> 0).
+
+"""
+        # get number of basis functions and output dtype
+        dummy = self.__call__(0.)
+        nbasis = dummy.shape[0]
+
+        tau = np.atleast_1d(tau)
+        if tau.ndim > 1:
+            raise ValueError("tau must be a list or a rank-1 array")
+
+        A = np.empty( (tau.shape[0], nbasis), dtype=dummy.dtype )
+        f = self.diff(order=deriv_order)
+        for i,taui in enumerate(tau):
+            A[i,:] = f(taui)
+
+        return np.squeeze(A)

--- a/bspline.py
+++ b/bspline.py
@@ -5,12 +5,12 @@ import matplotlib.pyplot as plt
 class memoize(object):
     """
        Cache the return value of a method
-        
+
        This class is meant to be used as a decorator of methods. The return value
        from a given method invocation will be cached on the instance whose method
        was invoked. All arguments passed to a method decorated with memoize must
        be hashable.
-        
+
        If a memoized method is invoked directly on its class the result will not
        be cached. Instead the method will be invoked like a static method:
        class Obj(object):
@@ -19,7 +19,7 @@ class memoize(object):
                return self + arg
        Obj.add_to(1) # not enough arguments
        Obj.add_to(1, 2) # returns 3, result is not cached
-        
+
        Script borrowed from here:
        MIT Licensed, attributed to Daniel Miller, Wed, 3 Nov 2010
        http://code.activestate.com/recipes/577452-a-memoize-decorator-for-instance-methods/
@@ -50,15 +50,15 @@ class Bspline():
        Numpy implementation of Cox - de Boor algorithm in 1D
 
        inputs:
-           knot_vector: Python list or Numpy array containing knot vector 
+           knot_vector: Python list or Numpy array containing knot vector
                         entries
-           order: Order of interpolation, e.g. 0 -> piecewise constant between 
+           order: Order of interpolation, e.g. 0 -> piecewise constant between
                   knots, 1 -> piecewise linear between knots, etc.
        outputs:
-           basis object that is callable to evaluate basis functions at given 
+           basis object that is callable to evaluate basis functions at given
            values of knot span
     """
-    
+
     def __init__(self, knot_vector, order):
         """Initialize attributes"""
         self.knot_vector = np.array(knot_vector)
@@ -67,51 +67,51 @@ class Bspline():
         #Dummy calls to the functions for memory storage
         self.__call__(0.0)
         self.d(0.0)
-        
-        
+
+
     def __basis0(self, xi):
         """Order zero basis"""
-        return np.where(np.all([self.knot_vector[:-1] <=  xi, 
+        return np.where(np.all([self.knot_vector[:-1] <=  xi,
                                 xi < self.knot_vector[1:]],axis=0), 1.0, 0.0)
-    
+
     def __basis(self, xi, p, compute_derivatives=False):
         """
-           Recursive Cox - de Boor function to compute basis functions and 
+           Recursive Cox - de Boor function to compute basis functions and
            optionally their derivatives
         """
-        
+
         if p == 0:
             return self.__basis0(xi)
         else:
             basis_p_minus_1 = self.__basis(xi, p - 1)
-        
-        first_term_numerator = xi - self.knot_vector[:-p] 
+
+        first_term_numerator = xi - self.knot_vector[:-p]
         first_term_denominator = self.knot_vector[p:] - self.knot_vector[:-p]
-        
+
         second_term_numerator = self.knot_vector[(p + 1):] - xi
-        second_term_denominator = (self.knot_vector[(p + 1):] - 
+        second_term_denominator = (self.knot_vector[(p + 1):] -
                                    self.knot_vector[1:-p])
-                
-        
+
+
         #Change numerator in last recursion if derivatives are desired
         if compute_derivatives and p == self.p:
-            
+
             first_term_numerator = p
             second_term_numerator = -p
-            
+
         #Disable divide by zero error because we check for it
         with np.errstate(divide='ignore', invalid='ignore'):
-            first_term = np.where(first_term_denominator != 0.0, 
-                                  (first_term_numerator / 
+            first_term = np.where(first_term_denominator != 0.0,
+                                  (first_term_numerator /
                                    first_term_denominator), 0.0)
             second_term = np.where(second_term_denominator != 0.0,
-                                   (second_term_numerator / 
+                                   (second_term_numerator /
                                     second_term_denominator), 0.0)
-        
-        return  (first_term[:-1] * basis_p_minus_1[:-1] + 
+
+        return  (first_term[:-1] * basis_p_minus_1[:-1] +
                  second_term * basis_p_minus_1[1:])
-            
-    
+
+
     @memoize
     def __call__(self, xi):
         """
@@ -119,49 +119,49 @@ class Bspline():
            for speed.
         """
         return self.__basis(xi, self.p, compute_derivatives=False)
-    
+
     @memoize
     def d(self, xi):
         """
-           Convenience function to compute derivate of basis functions.  
+           Convenience function to compute derivate of basis functions.
            'Memoized' for speed.
         """
         return self.__basis(xi, self.p, compute_derivatives=True)
-    
+
     def plot(self):
         """
-           Convenience function to plot basis functions over full 
+           Convenience function to plot basis functions over full
            range of knots.
         """
-        
+
         x_min = np.min(self.knot_vector)
         x_max = np.max(self.knot_vector)
-        
+
         x = np.linspace(x_min, x_max, num=1000)
-        
+
         N = np.array([self(i) for i in x]).T;
-        
+
         for n in N:
-            
+
             plt.plot(x,n)
-            
+
         return plt.show()
-    
+
     def dplot(self):
         """
-           Convenience function to plot derivatives of basis functions over 
+           Convenience function to plot derivatives of basis functions over
            full range of knots.
         """
-        
+
         x_min = np.min(self.knot_vector)
         x_max = np.max(self.knot_vector)
-        
+
         x = np.linspace(x_min, x_max, num=1000)
-        
+
         N = np.array([self.d(i) for i in x]).T;
-        
+
         for n in N:
-            
+
             plt.plot(x,n)
-            
+
         return plt.show()

--- a/bspline.py
+++ b/bspline.py
@@ -1,3 +1,7 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import division
+
 from functools import partial
 import numpy as np
 import matplotlib.pyplot as plt

--- a/demo.py
+++ b/demo.py
@@ -1,0 +1,172 @@
+# -*- coding: utf-8 -*-
+"""Demonstration / usage example for the new features.
+
+Created on Fri Mar 24 13:58:36 2017
+
+@author: Juha Jeronen, juha.jeronen@tut.fi
+"""
+
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+
+import matplotlib.pyplot as plt
+import matplotlib.cm
+import matplotlib.colors
+
+import bspline
+import splinelab
+
+
+def test():
+    ########################
+    # config
+    ########################
+
+    p      = 3  # order of spline basis (as-is! 3 = cubic)
+
+    nknots = 5  # for testing: number of knots to generate (here endpoints count only once)
+
+    tau = [0.1, 0.33]  # collocation sites (i.e. where to evaluate)
+
+    ########################
+    # usage example
+    ########################
+
+    knots = np.linspace(0,1,nknots)     # create a knot vector without endpoint repeats
+    k     = splinelab.augknt(knots, p)  # add endpoint repeats as appropriate for spline order p
+    B     = bspline.Bspline(k, p)       # create spline basis of order p on knots k
+
+    # build some collocation matrices:
+    #
+    A0 = B.collmat(tau)                 # function value at sites tau
+    A2 = B.collmat(tau, deriv_order=2)  # second derivative at sites tau
+
+    print( A0 )
+    print( A2 )
+
+    ########################
+    # tests
+    ########################
+
+    # number of basis functions
+    n_interior_knots = len(knots) - 2
+    n_basis_functions_expected = n_interior_knots + (p + 1)
+    n_basis_functions_actual = len(B(0.))  # perform dummy evaluation to get number of basis functions
+    assert n_basis_functions_actual == n_basis_functions_expected, "something went wrong, number of basis functions is incorrect"
+
+    # partition-of-unity property of the spline basis
+    assert np.allclose( np.sum(A0, axis=1), 1.0 ), "something went wrong, the basis functions do not form a partition of unity"
+
+
+def main():
+    """Demonstration: plot a B-spline basis and its first three derivatives."""
+
+    #########################################################################################
+    # config
+    #########################################################################################
+
+    # Order of spline basis.
+    #
+    p = 3
+
+    # Knot vector, including the endpoints.
+    #
+    # For convenience, endpoints are specified only once, regardless of the value of p.
+    #
+    # Duplicate knots *in the interior* are allowed, with the standard meaning for B-splines.
+    #
+    knots = [0., 0.25, 0.5, 0.75, 1.]
+
+    # How many plotting points to use on each subinterval [knots[i], knots[i+1]).
+    #
+    # Only intervals with length > 0 are actually plotted.
+    #
+    nt_per_interval = 101
+
+    #########################################################################################
+    # the demo itself
+    #########################################################################################
+
+    # The evaluation algorithm used in bspline.py uses half-open intervals  t_i <= x < t_{i+1}.
+    #
+    # This causes the right endpoint of each interval to actually be the start point of the next interval.
+    #
+    # Especially, the right endpoint of the last interval is the start point of the next (nonexistent) interval,
+    # so the basis will return a value of zero there.
+    #
+    # We work around this by using a small epsilon to avoid evaluation exactly at t_{i+1} (for each interval).
+    #
+    epsrel = 1e-10
+    epsabs = epsrel * (knots[-1] - knots[0])
+
+    original_knots = knots
+    knots = splinelab.augknt( knots, p )  # add repeated endpoint knots for splines of order p
+
+    # treat each interval separately to preserve discontinuities
+    #
+    # (useful especially when plotting the highest-order nonzero derivative)
+    #
+    B   = bspline.Bspline(knots, p)
+    xxs = []
+    for I in zip( knots[:-1], knots[1:] ):
+        t_i   = I[0]
+        t_ip1 = I[1] - epsabs
+        if t_ip1 - t_i > 0.:  # accept only intervals of length > 0 (to skip higher-multiplicity knots in the interior)
+            xxs.append( np.linspace(t_i, t_ip1, nt_per_interval) )
+
+    # common settings for all plotted lines
+    settings = { "linestyle" : 'solid',
+                 "linewidth" : 1.0 }
+
+    # create a list of unique colors for plotting
+    #
+    # http://stackoverflow.com/questions/8389636/creating-over-20-unique-legend-colors-using-matplotlib
+    #
+    NUM_COLORS = nbasis = len( B(0.) )  # perform dummy evaluation to get number of basis functions
+    cm         = plt.get_cmap('gist_rainbow')
+    cNorm      = matplotlib.colors.Normalize(vmin=0, vmax=NUM_COLORS-1)
+    scalarMap  = matplotlib.cm.ScalarMappable(norm=cNorm, cmap=cm)
+    colors     = [scalarMap.to_rgba(i) for i in range(NUM_COLORS)]
+
+    labels = [ r"$B$",
+               r"$\mathrm{d}B\,/\,\mathrm{d}x$",
+               r"$\mathrm{d}^2B\,/\,\mathrm{d}x^2$",
+               r"$\mathrm{d}^3B\,/\,\mathrm{d}x^3$" ]
+
+    # for plotting the knot positions:
+    unique_knots_xx = np.unique(original_knots)
+    unique_knots_yy = np.zeros_like(unique_knots_xx)
+
+    # plot the basis functions B(x) and their first three derivatives
+    plt.figure(1)
+    plt.clf()
+    for k in range(4):
+        ax = plt.subplot(2,2, k+1)
+
+        # place the axis label where it fits
+        if k % 2 == 0:
+            ax.yaxis.set_label_position("left")
+        else:
+            ax.yaxis.set_label_position("right")
+
+        # plot the kth derivative; each basis function gets a unique color
+        f = B.diff(order=k)  # order=0 is a passthrough
+        for xx in xxs:
+            yy = np.array( [f(x) for x in xx] )  # f(scalar) -> rank-1 array, one element per basis function
+            for i in range(nbasis):
+                settings["color"] = colors[i]
+                plt.plot( xx, yy[:,i], **settings )
+            plt.ylabel( labels[k] )
+
+        # show knot positions
+        plt.plot( unique_knots_xx, unique_knots_yy, "kx" )
+
+    plt.suptitle(r"$B$-spline basis functions, $p=%d$" % (p))
+
+
+if __name__ == '__main__':
+    test()
+    main()
+    plt.show()

--- a/splinelab.py
+++ b/splinelab.py
@@ -1,0 +1,214 @@
+# -*- coding: utf-8 -*-
+"""Utility functions for B-splines, potentially useful for converting MATLAB codes to Python.
+
+CAVEATS:
+    - Only a very minimal set of functionality is implemented here.
+    - Some technical details differ from the MATLAB equivalents.
+
+Particularly, we use spline order `p` **as-is** instead of MATLAB's `k` parameter (`k` = `p` + 1)
+in the function parameters.
+
+Created on Fri Mar 24 13:52:37 2017
+
+@author: Juha Jeronen, juha.jeronen@tut.fi
+"""
+
+from __future__ import division
+
+import numpy as np
+
+import bspline
+
+
+def augknt(knots, order):
+    """Augment a knot vector.
+
+Parameters:
+    knots:
+        Python list or rank-1 array, the original knot vector (without endpoint repeats)
+    order:
+        int, >= 0, order of spline
+
+Returns:
+    list_of_knots:
+        rank-1 array that has (`order` + 1) copies of ``knots[0]``, then ``knots[1:-1]``, and finally (`order` + 1) copies of ``knots[-1]``.
+
+Caveats:
+    `order` is the spline order `p`, not `p` + 1, and existing knots are never deleted.
+    The knot vector always becomes longer by calling this function.
+"""
+    if isinstance(knots, np.ndarray)  and  knots.ndim > 1:
+        raise ValueError("knots must be a list or a rank-1 array")
+    knots = list(knots)  # ensure Python list
+
+    # One copy of knots[0] and knots[-1] will come from "knots" itself,
+    # so we only need to prepend/append "order" copies.
+    #
+    return np.array( [knots[0]] * order  +  knots  +  [knots[-1]] * order )
+
+
+def aveknt(t, k):
+    """Compute the running average of `k` successive elements of `t`. Return the averaged array.
+
+Parameters:
+    t:
+        Python list or rank-1 array
+    k:
+        int, >= 2, how many successive elements to average
+
+Returns:
+    rank-1 array, averaged data. If k > len(t), returns a zero-length array.
+
+Caveat:
+    This is slightly different from MATLAB's aveknt, which returns the running average
+    of `k`-1 successive elements of ``t[1:-1]`` (and the empty vector if  ``len(t) - 2 < k - 1``).
+
+"""
+    t = np.atleast_1d(t)
+    if t.ndim > 1:
+        raise ValueError("t must be a list or a rank-1 array")
+
+    n = t.shape[0]
+    u = max(0, n - (k-1))  # number of elements in the output array
+    out = np.empty( (u,), dtype=t.dtype )
+
+    for j in xrange(u):
+        out[j] = sum( t[j:(j+k)] ) / k
+
+    return out
+
+
+def aptknt(tau, order):
+    """Create an acceptable knot vector.
+
+Minimal emulation of MATLAB's ``aptknt``.
+
+The returned knot vector can be used to generate splines of order `k` that are
+suitable for interpolation to the collocation sites `tau`.
+
+Parameters:
+    tau:
+        Python list or rank-1 array, collocation sites
+
+    order:
+        int, >= 0, order of spline
+
+Returns:
+    rank-1 array, `order` + 1 copies of ``tau[0]``, then ``aveknt(tau[1:-1],order)``,
+    and finally `order` + 1 copies of ``tau[-1]``.
+"""
+    tau = np.atleast_1d(tau)
+    k   = order + 1
+
+    if tau.ndim > 1:
+        raise ValueError("tau must be a list or a rank-1 array")
+
+    # emulate MATLAB behavior for the "k" parameter
+    #
+    # See
+    #   https://se.mathworks.com/help/curvefit/aptknt.html
+    #
+    if len(tau) < k:
+        k = len(tau)
+
+    if not (tau == sorted(tau)).all():
+        raise ValueError("tau must be nondecreasing")
+
+    # last processed element needs to be:
+    #     i + k - 1 = len(tau)- 1
+    # =>  i + k = len(tau)
+    # =>  i = len(tau) - k
+    #
+    u = len(tau) - k
+    for i in xrange(u):
+        if tau[i+k-1] == tau[i]:
+            raise ValueError("k-fold (or higher) repeated sites not allowed, but tau[i+k-1] == tau[i] for i = %d, k = %d" % (i,k))
+
+    # form the output sequence
+    #
+    prefix = [ tau[0]  ] * k
+    suffix = [ tau[-1] ] * k
+
+    # https://se.mathworks.com/help/curvefit/aveknt.html
+    # MATLAB's aveknt():
+    #  - averages successive k-1 entries, but ours averages k
+    #  - seems to ignore the endpoints
+    #
+    tmp    = aveknt(tau[1:-1], k-1)
+    middle = tmp.tolist()
+    return np.array( prefix + middle + suffix, dtype=tmp.dtype )
+
+
+def knt2mlt(t):
+    """Count multiplicities of elements in a sorted list or rank-1 array.
+
+Minimal emulation of MATLAB's ``knt2mlt``.
+
+Parameters:
+    t:
+        Python list or rank-1 array. Must be sorted!
+
+Returns:
+    out
+        rank-1 array such that
+        out[k] = #{ t[i] == t[k] for i < k }
+
+Example:
+    If ``t = [1, 1, 2, 3, 3, 3]``, then ``out = [0, 1, 0, 0, 1, 2]``.
+
+Caveat:
+    Requires input to be already sorted (this is not checked).
+"""
+    t = np.atleast_1d(t)
+    if t.ndim > 1:
+        raise ValueError("t must be a list or a rank-1 array")
+
+    out   = []
+    e     = None
+    for k in xrange(t.shape[0]):
+        if t[k] != e:
+            e     = t[k]
+            count = 0
+        else:
+            count += 1
+        out.append(count)
+
+    return np.array( out )
+
+
+def spcol(knots, order, tau):
+    """Return collocation matrix.
+
+Minimal emulation of MATLAB's ``spcol``.
+
+Parameters:
+    knots:
+        rank-1 array, knot vector (with appropriately repeated endpoints; see `augknt`, `aptknt`)
+    order:
+        int, >= 0, order of spline
+    tau:
+        rank-1 array, collocation sites
+
+Returns:
+    rank-2 array A such that
+
+        A[i,j] = D**{m(i)} B_j(tau[i])
+
+    where
+        m(i) = multiplicity of site tau[i]
+
+        D**k  = kth derivative (0 for function value itself)
+"""
+    m = knt2mlt(tau)
+    B = bspline.Bspline(knots, order)
+
+    dummy = B(0.)
+    nbasis = len(dummy)  # perform dummy evaluation to get number of basis functions
+
+    A = np.empty( (tau.shape[0], nbasis), dtype=dummy.dtype )
+    for i,item in enumerate(zip(tau,m)):
+        taui,mi = item
+        f       = B.diff(order=mi)
+        A[i,:]  = f(taui)
+
+    return A

--- a/splinelab.py
+++ b/splinelab.py
@@ -72,7 +72,7 @@ Caveat:
     u = max(0, n - (k-1))  # number of elements in the output array
     out = np.empty( (u,), dtype=t.dtype )
 
-    for j in xrange(u):
+    for j in range(u):
         out[j] = sum( t[j:(j+k)] ) / k
 
     return out
@@ -120,7 +120,7 @@ Returns:
     # =>  i = len(tau) - k
     #
     u = len(tau) - k
-    for i in xrange(u):
+    for i in range(u):
         if tau[i+k-1] == tau[i]:
             raise ValueError("k-fold (or higher) repeated sites not allowed, but tau[i+k-1] == tau[i] for i = %d, k = %d" % (i,k))
 
@@ -165,7 +165,7 @@ Caveat:
 
     out   = []
     e     = None
-    for k in xrange(t.shape[0]):
+    for k in range(t.shape[0]):
         if t[k] != e:
             e     = t[k]
             count = 0

--- a/splinelab.py
+++ b/splinelab.py
@@ -83,8 +83,14 @@ def aptknt(tau, order):
 
 Minimal emulation of MATLAB's ``aptknt``.
 
-The returned knot vector can be used to generate splines of order `k` that are
-suitable for interpolation to the collocation sites `tau`.
+The returned knot vector can be used to generate splines of desired `order`
+that are suitable for interpolation to the collocation sites `tau`.
+
+Note that this is only possible when ``len(tau)`` >= `order` + 1.
+
+When this condition does not hold, a valid knot vector is returned,
+but using it to generate a spline basis will not have the desired effect
+(the spline will return a length-zero array upon evaluation).
 
 Parameters:
     tau:
@@ -94,8 +100,8 @@ Parameters:
         int, >= 0, order of spline
 
 Returns:
-    rank-1 array, `order` + 1 copies of ``tau[0]``, then ``aveknt(tau[1:-1],order)``,
-    and finally `order` + 1 copies of ``tau[-1]``.
+    rank-1 array, `k` copies of ``tau[0]``, then ``aveknt(tau[1:-1], k-1)``,
+    and finally `k` copies of ``tau[-1]``, where ``k = min(order+1, len(tau))``.
 """
     tau = np.atleast_1d(tau)
     k   = order + 1


### PR DESCRIPTION
Hi,

Thanks for the implementation, this module did almost exactly what I needed :)

As for the "almost" part, here's a patch to add higher-order differentiation, collocation matrix generation, and a minimal procedural API (mainly for dealing with knot vectors) which may help in converting MATLAB codes. I also took the liberty to clean up trailing whitespace, specify the character encoding, and add `from __future__ import division` for Python 2.7.

Comments are welcome.